### PR TITLE
Fix version file URL property

### DIFF
--- a/Constellations.version
+++ b/Constellations.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Contract Pack: Constellations",
-    "URL":"https://forum.kerbalspaceprogram.com/topic/224837-112x-contract-pack-constellations/",
+    "URL":"https://raw.githubusercontent.com/IO5/KspConstellations/master/Constellations.version",
     "DOWNLOAD":"https://spacedock.info/mod/3601/Contract%20Pack:%20Constellations",
     "GITHUB":{
         "USERNAME":"IO5",


### PR DESCRIPTION
Hi @IO5, the `URL` property of a version file is meant to point to an online copy of the version file itself, in case there were changes in compatibility since the release was made, not the mod's home page. This PR fixes it.
Cheers!

Noticed while working on KSP-CKAN/NetKAN#10025.
